### PR TITLE
Check contrast ratio

### DIFF
--- a/src/contrast.js
+++ b/src/contrast.js
@@ -8,6 +8,10 @@ const contrast = (color, dark = parse("#000"), light = parse("#FFF")) => {
 
   const contrastColor = baseColor.isDark() ? lightColor : darkColor;
 
+  /**
+   * Calculate relative luminance and find ratio
+   * https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G18
+   */
   const rLums = [ relativeLuminance(baseColor), relativeLuminance(contrastColor)];
 
   const contrastRatio = (Math.max(...rLums) + 0.05) / (Math.min(...rLums) + 0.05);

--- a/src/contrast.js
+++ b/src/contrast.js
@@ -1,8 +1,22 @@
 import parse from "./parse";
+import relativeLuminance from "./relativeLuminance";
 
-export default (color, dark = parse("#000"), light = parse("#FFF")) => {
-  const darkColor = (typeof dark === "string") ? parse(dark) : dark;
-  const lightColor = (typeof light === "string") ? parse(light) : light;
-  const c = parse(color);
-  return c.luma < 128 ? lightColor : darkColor;
-}
+const contrast = (color, dark = parse("#000"), light = parse("#FFF")) => {
+  const baseColor = parse(color);
+  const darkColor = typeof dark === "string" ? parse(dark) : dark;
+  const lightColor = typeof light === "string" ? parse(light) : light;
+
+  const contrastColor = baseColor.isDark() ? lightColor : darkColor;
+
+  const rLums = [ relativeLuminance(baseColor), relativeLuminance(contrastColor)];
+
+  const contrastRatio = (Math.max(...rLums) + 0.05) / (Math.min(...rLums) + 0.05);
+
+  if (contrastRatio >= 4.5) {
+    return contrastColor;
+  }
+
+  return contrast(baseColor, darkColor.darken(1), lightColor.lighten(1));
+};
+
+export default contrast;

--- a/src/luma.js
+++ b/src/luma.js
@@ -1,1 +1,6 @@
+/** 
+ * Based on the Y value in https://en.m.wikipedia.org/wiki/YIQ
+ * Used to calculate perceived brightness in accessibility W3C spec
+ * https://www.w3.org/TR/AERT#color-contrast
+ */
 export default (r, g, b) => (299 * r + 587 * g + 114 * b) / 1000;

--- a/src/luma.js
+++ b/src/luma.js
@@ -1,0 +1,1 @@
+export default (r, g, b) => (299 * r + 587 * g + 114 * b) / 1000;

--- a/src/make.js
+++ b/src/make.js
@@ -30,6 +30,12 @@ const makeColor = (properties) => {
 
   return {
     ...color,
+    isDark() {
+      return color.luma < 128;
+    },
+    isLight() {
+      return color.luma >= 128;
+    },
     setLightness(percentage) {
       return setLightness(color, percentage);
     },

--- a/src/make.js
+++ b/src/make.js
@@ -4,6 +4,7 @@ import { fadeIn, fadeOut, setAlpha } from "./alpha";
 import contrast from "./contrast";
 import saturate from "./saturate";
 import desaturate from "./desaturate";
+import luma from "./luma";
 
 const makeColor = (properties) => {
   const { rHex, gHex, bHex, r, g, b, h, s, l, a = 1 } = properties;
@@ -25,7 +26,7 @@ const makeColor = (properties) => {
         : `hsl(${h},${s}%,${l}%)`
       ;
     },
-    luma: (299 * r + 587 * g + 114 * b) / 1000,
+    luma: luma(r, g, b),
   }
 
   return {

--- a/src/relativeLuminance.js
+++ b/src/relativeLuminance.js
@@ -1,0 +1,10 @@
+export default color => {
+  const [R, G, B] = [color.r, color.g, color.b].map(channel => {
+    const sRGB = channel / 255;
+    return sRGB <= 0.03928
+      ? sRGB / 12.92
+      : Math.pow((sRGB + 0.055) / 1.055, 2.4);
+  });
+
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+};

--- a/src/relativeLuminance.js
+++ b/src/relativeLuminance.js
@@ -1,3 +1,6 @@
+/**
+ * https://en.m.wikipedia.org/wiki/Relative_luminance
+ */
 export default color => {
   const [R, G, B] = [color.r, color.g, color.b].map(channel => {
     const sRGB = channel / 255;


### PR DESCRIPTION
Fixes #10 

With these changes, a user will always get a valid contrast ratio, even if they pass in a value that does not meet the requirement.
 
```js
const black = polychrome("#000");

// returns a polychrome with hex value #757575
const contrastColor = black.contrast("#000", "#555") 
```
> Since black is a dark color, the `light` parameter (`#555`) will be chosen as the contrast color.
 However, since the contrast ratio between `#555` and `#000` is not at least `4.5 : 1`, `#555` will be lightened 1% and checked again. This happens until a valid ratio is reached.